### PR TITLE
The Felix plugin needs just the symbolic name setting

### DIFF
--- a/pfl-basic-tools/pom.xml
+++ b/pfl-basic-tools/pom.xml
@@ -37,11 +37,6 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${project.name}</Bundle-Name>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <Export-Package>
-                            org.glassfish.pfl.basic.tools.*                   
-                        </Export-Package>             
                     </instructions>
                 </configuration>
             </plugin>
@@ -67,7 +62,7 @@
            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-            </plugin> 
+            </plugin>
          </plugins>
     </build>
 

--- a/pfl-basic/pom.xml
+++ b/pfl-basic/pom.xml
@@ -31,25 +31,12 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${project.name}</Bundle-Name>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <Export-Package>
-                            !org.glassfish.pfl.basic.tools.*,
-                            org.glassfish.pfl.basic.*
-                        </Export-Package>
-                        <Import-Package>
-                            sun.misc;resolution:=optional,
-                            sun.reflect;resolution:=optional,
-                            *
-                        </Import-Package>
                     </instructions>
                 </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>manifest</goal>
-                            <goal>install</goal>
-                            <goal>deploy</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pfl-dynamic/pom.xml
+++ b/pfl-dynamic/pom.xml
@@ -55,19 +55,12 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${project.name}</Bundle-Name>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <Export-Package>
-                            org.glassfish.pfl.dynamic.*
-                        </Export-Package>
                     </instructions>
                 </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>manifest</goal>
-                            <goal>install</goal>
-                            <goal>deploy</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pfl-test/pom.xml
+++ b/pfl-test/pom.xml
@@ -70,11 +70,6 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${project.name}</Bundle-Name>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <Export-Package>
-                            org.glassfish.pfl.test.*
-                        </Export-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/pfl-tf-tools/pom.xml
+++ b/pfl-tf-tools/pom.xml
@@ -47,11 +47,6 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${project.name}</Bundle-Name>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <Export-Package>
-                            org.glassfish.pfl.tf.tools.*
-                        </Export-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/pfl-tf/pom.xml
+++ b/pfl-tf/pom.xml
@@ -49,12 +49,6 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${project.name}</Bundle-Name>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <Export-Package>
-                            org.glassfish.pfl.tf.spi.*,
-                            org.glassfish.pfl.tf.timer.*
-                        </Export-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
- By default, Felix changes - to a . (dot)
- Fix for snapshot: Version included snapshot, that breaks usages
- sun packages in pfl-basic are not optional, sorry, you use Unsafe.
- I don't see the reason to run Felix install+deploy in pfl-basic