### PR TITLE
Using Temurin 21 instead of OpenJdk 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
   agent any
   tools {
     maven 'apache-maven-latest'
-    jdk 'openjdk-jdk17-latest'
+    jdk 'temurin-jdk21-latest'
   }
   stages {
     stage('build') {


### PR DESCRIPTION
- However we still build for JDK11.
- It would be good to run tests also for other versions